### PR TITLE
Hotfix/add fixed isolation level 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Support for column names that contain unusual characters, like "-", " ", ".", "/
 **Version 0.3.0:**
 * Adding fixed version for generated API libraries to avoid breaking changes
 
+**Version 0.3.1:**
+* Setting READ COMMITTED isolation level on mysql and mariadb resolvers
+
 ## Installation
 
 To begin working with PythonREST, you can visit our [website's download page](https://pythonrest.seventechnologies.cloud/en/download) and download the installer for your system or if you're more

--- a/apigenerator/resources/1 - Project/2 - Database/conn_resolvers/mariadb/MariaDbConnectionResolver.py
+++ b/apigenerator/resources/1 - Project/2 - Database/conn_resolvers/mariadb/MariaDbConnectionResolver.py
@@ -22,7 +22,7 @@ def get_mariadb_connection_session():
     if session is None:
         # This block creates engine and session for the database #
             conn = get_mariadb_connection_schema_internet()
-            engine = sa.create_engine(conn)
+            engine = sa.create_engine(conn, isolation_level="READ COMMITTED")
             session = scoped_session(sessionmaker(bind=engine))
 
     # Returning session #

--- a/apigenerator/resources/1 - Project/2 - Database/conn_resolvers/mysql/MySqlConnectionResolver.py
+++ b/apigenerator/resources/1 - Project/2 - Database/conn_resolvers/mysql/MySqlConnectionResolver.py
@@ -22,7 +22,7 @@ def get_mysql_connection_session():
     if session is None:
         # This block creates engine and session for the database #
             conn = get_mysql_connection_schema_internet()
-            engine = sa.create_engine(conn)
+            engine = sa.create_engine(conn, isolation_level="READ COMMITTED")
             session = scoped_session(sessionmaker(bind=engine))
 
     # Returning session #

--- a/pythonrest.py
+++ b/pythonrest.py
@@ -17,7 +17,7 @@ from apigenerator.e_Enumerables.Enumerables import get_directory_data
 
 
 app = typer.Typer()
-pythonrest_version = "0.3.0"
+pythonrest_version = "0.3.1"
 
 
 @app.command()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def list_files_by_extension(directory='.', extension=()):
 
 setup(
     name='pythonrest3',
-    version='0.3.0',
+    version='0.3.1',
     description='A CLI tool that generates a complete API using a connection string for supported databases: mysql, mssql, mariadb and postgres',
     long_description=(
         "# PythonREST\n\n"
@@ -72,7 +72,9 @@ setup(
         "**Version 0.2.9**\n"
         "* Support for columns named with Python reserved keywords\n\n"
         "**Version 0.3.0**\n"
-        "* Adding fixed version for generated API libraries to avoid breaking changes\n"
+        "* Adding fixed version for generated API libraries to avoid breaking changes\n\n"
+        "**Version 0.3.1**\n"
+        "* Setting READ COMMITTED isolation level on mysql and mariadb resolvers\n"
     ),
     long_description_content_type="text/markdown",
     author='Seven Technologies Cloud',


### PR DESCRIPTION
- Setting READ COMMITTED isolation level on mysql and mariadb resolvers, since those two default isolation levels are set to READ COMMITTED, which can lead to sessions created before new data arrives to fetch old data instead.
- PostgresSQL and SQLServer remained intact, since the default isolation level for them are already READ COMMITTED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- MySQL and MariaDB database connections now use the READ COMMITTED transaction isolation level by default.
- **Documentation**
	- Updated version information and changelog to reflect the new database isolation level setting.
- **Chores**
	- Bumped application version to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->